### PR TITLE
Add Stratara to .NET Libraries/Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Inspired by [all the other awesome things](https://github.com/bayandin/awesome-a
 - [Eventuous](https://github.com/Eventuous/eventuous) - Minimalistic Event Sourcing library for .NET (KurrentDB)
 - [Propulsion](https://github.com/jet/propulsion) - .NET event stream projection and scheduling platform with EventStore, CosmosDb, Equinox and Kafka integrations
 - [Memstate](https://github.com/DevrexLabs/memstate) - In-memory event-sourced ACID-transactional distributed object graph engine for .NET Standard.
+- [Stratara](https://github.com/yesbert/Stratara) - CQRS and Event Sourcing for .NET with tamper-evident event streams and tenant-aware encryption built in.
 - [castore](https://github.com/castore-dev/castore) - Typescript library to easily implement Event Sourcing on your project
 - [OpenCQRS](https://www.opencqrs.com/) – Java CQRS Framework for the EventSourcingDB
 - [CQRSKit](https://github.com/patriceckhart/cqrskit) - A TypeScript CQRS and Event Sourcing framework with pluggable database adapters


### PR DESCRIPTION
Adds [Stratara](https://github.com/yesbert/Stratara) — an integrated CQRS + Event Sourcing stack for .NET 10.

What sets it apart from the .NET frameworks already listed: event streams are hash-chained, so you can prove an audit log wasn't tampered with, and per-tenant payload encryption is built in (AES-GCM with the tenant id as AAD) rather than bolted on. Mediator, transactional outbox, sagas, projections and identity all ship in one lockstep-versioned package family — no composition tax from wiring five libraries together.

- Project: https://github.com/yesbert/Stratara
- Docs: https://docs.stratara.tech
- NuGet: `dotnet add package Stratara.Mediator` (20 packages, all public)

Actively maintained, documented, and test-covered. Source-available under FSL-1.1-MIT (converts to MIT after two years).